### PR TITLE
Add FidoNet bibref, gpul citation and minor fix to avoid blank pake

### DIFF
--- a/anexos/gpul.tex
+++ b/anexos/gpul.tex
@@ -5,8 +5,8 @@
 \chapter{GPUL: +25 Years Freeing Minds}
 
 \lettrine{S}{ince} its founding in September~1998, the Group of Programmers
-and Users of Linux (GPUL) has been a driving force for Free Software in A~Coru\~na.
-Closely tied to the Faculty of Computer Science at the University of
+and Users of Linux (GPUL) \cite{gpul-web} has been a driving force for Free Software in A~Coru\~na.
+Rooted in the Faculty of Computer Science at the University of
 A Coru\~na, this \gls{glug} began as a student initiative to promote open
 standards and the GNU/Linux ecosystem. The original bylaws highlighted
 the importance of open development and explicitly named Linux as one of
@@ -32,7 +32,7 @@ minutes of its first board meeting:
 GPUL's roots go back to the Faculty's \gls{bbs}, FiCBBS, which began
 operating in 1992. Bulletin Board Systems such as this allowed users to
 exchange messages and files via modem long before widespread internet
-access. By the mid--1990s a small but enthusiastic group on the
+access \cite{Fido93}. By the mid--1990s a small but enthusiastic group on the
 \texttt{fic.linux} area of FiCBBS was experimenting with the early
 GNU/Linux distributions, coordinating meetups and even bulk ordering CDs
 to ease installation. The momentum of that community culminated in the

--- a/bibliografia/bibliografia.bib
+++ b/bibliografia/bibliografia.bib
@@ -513,3 +513,14 @@
   year = {2000},
   url = {https://trasno.gal},
 }
+
+@Article{Fido93,
+  author =       {Randy Bush},
+  title =        {{FidoNet}: technology, tools, and history},
+  journal =      {Communications of the ACM},
+  year =         {1993},
+  volume =       {36},
+  number =       {8},
+  pages =        {31--35},
+  note =         {\url{https://dl.acm.org/doi/pdf/10.1145/163381.163383}}
+}

--- a/memoria_tfg.tex
+++ b/memoria_tfg.tex
@@ -103,7 +103,7 @@
 
   \appendix
   \appendixpage
-  \include{anexos/gpul.tex}
+  \input{anexos/gpul.tex}
   %\include{anexos/...}
 
   \printglossary[type=\acronymtype,title=\nomeglosarioacronimos]


### PR DESCRIPTION
I added a journal paper about FidoNet to bibliography (it will be a good idea to add more bibrefs to academy and research works: journals, conferences, etc.)

I also included a \cite to GPUL's bibref in the appendix, and fix the blank page issue.
[Uploading memoria_tfg.pdf…]()
